### PR TITLE
feat (account): Implement change password functionality

### DIFF
--- a/cocktails.web/src/App.tsx
+++ b/cocktails.web/src/App.tsx
@@ -28,6 +28,7 @@ const AccountNavigationPage = React.lazy(() => import('./pages/AccountPages/Acco
 const AccountProfileImagePage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountProfileImagePage/AccountProfileImagePage'));
 const AccountPersonalDetailsPage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountPersonalDetailsPage/AccountPersonalDetailsPage'));
 const AccountChangeEmailPage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountChangeEmailPage/AccountChangeEmailPage'));
+const ChangeAccountPasswordPage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPage'));
 const AccountAccessibilityPage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountAccessibilityPage/AccountAccessibilityPage'));
 const AccountFavoriteCocktailsPage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountFavoriteCocktailsPage/AccountFavoriteCocktailsPage'));
 const AccountTermsOfServicePage = React.lazy(() => import('./pages/AccountPages/AccountChildPages/AccountTermsOfServicePage/AccountTermsOfServicePage'));
@@ -244,6 +245,14 @@ const router = createBrowserRouter(
                                     element: (
                                         <React.Suspense>
                                             <AccountChangeEmailPage />
+                                        </React.Suspense>
+                                    )
+                                },
+                                {
+                                    path: '/account/profile-center/change-password',
+                                    element: (
+                                        <React.Suspense>
+                                            <ChangeAccountPasswordPage />
                                         </React.Suspense>
                                     )
                                 },

--- a/cocktails.web/src/api/cocktailsApi/cocktailsApiClient.ts
+++ b/cocktails.web/src/api/cocktailsApi/cocktailsApiClient.ts
@@ -839,6 +839,49 @@ export class CocktailsApiClient extends CocktailsApiClientBase {
             });
         }
     }
+
+    /**
+     * @param body The account password update request body
+     * @param x_Key (optional) Subscription key
+     * @return No Content
+     */
+    changeAccountOwnedPassword(body: ChangeAccountOwnedPasswordRq, x_Key?: string | undefined): Promise<void> {
+        let url_ = this.baseUrl + "/api/v1/accounts/owned/profile/password";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(body);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "X-Key": x_Key !== undefined && x_Key !== null ? "" + x_Key : "",
+                "Content-Type": "application/json; x-api-version=1.0",
+            }
+        };
+
+        return this.transformOptions(options_).then(transformedOptions_ => {
+            return this.http.fetch(url_, transformedOptions_);
+        }).then((_response: Response) => {
+            return this.transformResult(url_, _response, (_response: Response) => this.processChangeAccountOwnedPassword(_response));
+        });
+    }
+
+    protected processChangeAccountOwnedPassword(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else {
+            return response.text().then((_responseText) => {
+            let resultdefault: any = null;
+            resultdefault = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver) as ProblemDetails;
+            return throwException("A server side error occurred.", status, _responseText, _headers, resultdefault);
+            });
+        }
+    }
 }
 
 /** The accessibility settings for the account */
@@ -933,6 +976,13 @@ export interface AccountOwnedProfileRs {
     /** The list of favorite cocktails */
     favoriteCocktails: string[];
     notifications: AccountNotificationSettingsModel;
+
+    [key: string]: any;
+}
+
+export interface ChangeAccountOwnedPasswordRq {
+    /** The email address for the account */
+    email: string;
 
     [key: string]: any;
 }

--- a/cocktails.web/src/organisims/AccountNavigationBar/AccountNavigationBar.tsx
+++ b/cocktails.web/src/organisims/AccountNavigationBar/AccountNavigationBar.tsx
@@ -34,7 +34,7 @@ const AccountNavigationBar = ({ testId, fullScreen = false }: AccountNavigationB
                     </Typography>
                     <ProfileSettingItemLink icon={<PersonIcon />} text='Personal details' testId='p-settings-personal-details' navigatePath='/account/profile-center/personal-details' />
                     <ProfileSettingItemLink icon={<FaceIcon />} text='Profile Image' testId='p-settings-profile-image' navigatePath='/account/profile-center/avatar' />
-                    <ProfileSettingItemLink icon={<SecurityIcon />} text='Change Password' testId='p-settings-password' navigatePath='/account/profile-center#' onClick={() => {}} />
+                    <ProfileSettingItemLink icon={<SecurityIcon />} text='Change Password' testId='p-settings-password' navigatePath='/account/profile-center/change-password' onClick={() => {}} />
                     <ProfileSettingItemLink icon={<MailLockIcon />} text='Change Email' testId='p-settings-email' navigatePath='/account/profile-center/change-email' />
                     <ProfileSettingItemLink icon={<NightlightIcon />} text='Display & accessibility' testId='p-settings-accessibility' navigatePath='/account/profile-center/accessibility' />
                 </CardContent>

--- a/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPage.test.tsx
+++ b/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPage.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
+import ChangeAccountPasswordPage from './ChangeAccountPasswordPage';
+import GlobalContext from '../../../../components/GlobalContexts';
+import { Auth0ReactTester } from '../../../../auth0Mocks';
+import { Auth0Provider } from '../../../../components/Auth0Provider';
+import { getTestUser } from '../../../../../tests/setup';
+import { auth0TestProviderOptions } from '../../../../auth0Mocks/testerConstants';
+
+describe('Change Account Password Page', () => {
+    let auth0Tester: Auth0ReactTester;
+
+    beforeEach(() => {
+        auth0Tester = new Auth0ReactTester('Redirect');
+        auth0Tester.spyAuth0();
+    });
+
+    afterEach(() => {
+        auth0Tester.resetSpyAuth0();
+    });
+
+    test('renders change account password page', async () => {
+        const router = createMemoryRouter(createRoutesFromElements(<Route path='/account/profile-center/change-password' element={<ChangeAccountPasswordPage />} />), {
+            initialEntries: ['/account/profile-center/change-password']
+        });
+
+        auth0Tester.isLogged();
+        auth0Tester.user = getTestUser();
+
+        render(
+            <Auth0Provider {...auth0TestProviderOptions} onClientCreated={() => auth0Tester.client}>
+                <GlobalContext>
+                    <RouterProvider router={router} />
+                </GlobalContext>
+            </Auth0Provider>
+        );
+
+        await screen.findByText('Profile Center');
+        const elements = screen.getAllByText('Change Password');
+        expect(elements.length).toBe(2);
+
+        expect(document.title).toBe('Profile Center - Change Password');
+    });
+});

--- a/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPage.tsx
+++ b/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPage.tsx
@@ -1,0 +1,5 @@
+import ChangeAccountPasswordPageContainer from './ChangeAccountPasswordPageContainer';
+
+const ChangeAccountPasswordPage = () => <ChangeAccountPasswordPageContainer />;
+
+export default ChangeAccountPasswordPage;

--- a/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPageContainer.test.tsx
+++ b/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPageContainer.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import GlobalContext from '../../../../components/GlobalContexts';
+import ChangeAccountPasswordPageContainer from './ChangeAccountPasswordPageContainer';
+import { Auth0ReactTester } from '../../../../auth0Mocks';
+import { Auth0Provider } from '../../../../components/Auth0Provider';
+import { getTestUser } from '../../../../../tests/setup';
+import { auth0TestProviderOptions } from '../../../../auth0Mocks/testerConstants';
+
+describe('Account Change Password Page Container', () => {
+    let auth0Tester: Auth0ReactTester;
+
+    beforeEach(() => {
+        auth0Tester = new Auth0ReactTester('Redirect');
+        auth0Tester.spyAuth0();
+    });
+
+    afterEach(() => {
+        auth0Tester.resetSpyAuth0();
+    });
+
+    test('renders account change password page container', async () => {
+        auth0Tester.isLogged();
+        auth0Tester.user = getTestUser();
+
+        render(
+            <Auth0Provider {...auth0TestProviderOptions} onClientCreated={() => auth0Tester.client}>
+                <GlobalContext>
+                    <MemoryRouter>
+                        <ChangeAccountPasswordPageContainer />
+                    </MemoryRouter>
+                </GlobalContext>
+            </Auth0Provider>
+        );
+
+        await screen.findByText('Profile Center');
+        const elements = screen.getAllByText('Change Password');
+        expect(elements.length).toBe(2);
+
+        expect(document.title).toBe('Profile Center - Change Password');
+    });
+});

--- a/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPageContainer.tsx
+++ b/cocktails.web/src/pages/AccountPages/AccountChildPages/ChangeAccountPassword/ChangeAccountPasswordPageContainer.tsx
@@ -1,0 +1,99 @@
+import { Button, Divider, Grid, Typography, useMediaQuery } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { useOwnedAccount } from '../../../../components/OwnedAccountContext';
+import { changeOwnedAccountProfilePassword } from '../../../../services/AccountService';
+import theme from '../../../../theme';
+import trimWhack from '../../../../utils/trimWhack';
+import { getWindowEnv } from '../../../../utils/envConfig';
+import BackArrowLinkItem from '../../../../molecules/BackArrowLinkItem/BackArrowLinkItem';
+import startPageViewSpan from '../../../../services/Tracer';
+import AlertDialog from '../../../../molecules/AlertDialog/AlertDialog';
+
+const ChangeAccountPasswordPageContainer = () => {
+    const { ownedAccount } = useOwnedAccount();
+    const [openConfirmation, setOpenConfirmation] = useState<boolean>(false);
+    const isSmOrXs = useMediaQuery(theme.breakpoints.down('md'));
+
+    const handleCancelChangePassword = async () => {
+        setOpenConfirmation(false);
+    };
+
+    const confirmChangePassword = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        setOpenConfirmation(true);
+    };
+
+    const handleChangePassword = async () => {
+        await changeOwnedAccountProfilePassword({
+            email: ownedAccount?.email ?? ''
+        });
+
+        setOpenConfirmation(false);
+        toast.success('An email to change your password has been sent!', { position: 'top-left' });
+    };
+
+    useEffect(() => {
+        startPageViewSpan((span) => span.end());
+    }, []);
+
+    return (
+        <>
+            <title>Profile Center - Change Password</title>
+            <link rel='canonical' href={`${trimWhack(getWindowEnv().VITE_AUTH0_REDIRECT_URI)}/account/profile-center/change-password`} />
+            <meta name='robots' content='noindex,follow' />
+
+            {isSmOrXs && <BackArrowLinkItem />}
+
+            <Grid
+                container
+                sx={{
+                    pt: isSmOrXs ? '0px' : '40px',
+                    pl: isSmOrXs ? '10px' : '0px',
+                    pr: isSmOrXs ? '10px' : '0px',
+                    pb: '40px',
+                    mr: '0px'
+                }}
+            >
+                <Grid size={12} sx={{ pt: '5px' }}>
+                    <Typography variant='h6'>Profile Center</Typography>
+                </Grid>
+                <Grid id='change-email' size={12} sx={{ pb: '50px' }}>
+                    <Grid
+                        container
+                        sx={{
+                            pt: '20px'
+                        }}
+                    >
+                        <Grid size={12} sx={{ pb: '10px' }}>
+                            <Typography variant='h6'>Change Password</Typography>
+                            <Divider />
+                            <Typography sx={{ pt: '10px', color: 'text.secondary' }}>
+                                Click the button below to change your password. An email will be sent to you with instructions to enter your new password and confirm the change.
+                                <br />
+                                <br />
+                            </Typography>
+                        </Grid>
+
+                        <Grid size={12} sx={{ backgroundColor: 'rgba(245,245,245,.5)' }}>
+                            <Button data-testid='btnChangePassword' variant='outlined' color='primary' onClick={confirmChangePassword}>
+                                Change Password
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Grid>
+            <AlertDialog
+                open={openConfirmation}
+                title='Change your password?'
+                content='Are you sure you would like to change your password?  An email will be sent to you with instructions to enter your new password and confirm the change.'
+                cancelButtonText='Cancel'
+                confirmButtonText='Change Password'
+                onCancel={handleCancelChangePassword}
+                onConfirm={handleChangePassword}
+            />
+        </>
+    );
+};
+
+export default ChangeAccountPasswordPageContainer;

--- a/cocktails.web/src/services/AccountService.ts
+++ b/cocktails.web/src/services/AccountService.ts
@@ -1,6 +1,7 @@
 import {
     AccountCocktailRatingsRs,
     AccountOwnedProfileRs,
+    ChangeAccountOwnedPasswordRq,
     CocktailsApiClient,
     ManageFavoriteCocktailsRq,
     ProblemDetails,
@@ -122,6 +123,19 @@ const updateOwnedAccountProfileEmail = async (request: UpdateAccountOwnedProfile
         }
 
         return results;
+    } catch (e: unknown) {
+        const apiError: ProblemDetails = e as ProblemDetails;
+        const errorMessage = apiError?.errors?.length > 0 ? apiError.errors[0] : 'unknown error';
+        const error = new Error(errorMessage);
+        throw error;
+    }
+};
+
+const changeOwnedAccountProfilePassword = async (request: ChangeAccountOwnedPasswordRq): Promise<void> => {
+    try {
+        const cocktailsApiClient = new CocktailsApiClient();
+        cocktailsApiClient.setRequiredScopes([accountReadScope, accountWriteScope]);
+        await cocktailsApiClient.changeAccountOwnedPassword(request, undefined);
     } catch (e: unknown) {
         const apiError: ProblemDetails = e as ProblemDetails;
         const errorMessage = apiError?.errors?.length > 0 ? apiError.errors[0] : 'unknown error';
@@ -280,5 +294,6 @@ export {
     rateCocktail,
     getAccountCocktailRatings,
     sendRecommendation,
-    updateOwnedAccountNotificationsSettings
+    updateOwnedAccountNotificationsSettings,
+    changeOwnedAccountProfilePassword
 };


### PR DESCRIPTION
#61 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Change Password page under Profile Center with confirmation dialog and success toast.
  - Introduced route /account/profile-center/change-password and updated navigation link accordingly.
  - Lazy-loaded the page for improved initial load performance.
  - Enabled password change requests for the signed-in account.

- Tests
  - Added unit tests for ChangeAccountPasswordPage and its container, validating rendering, titles, and presence of “Change Password” content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->